### PR TITLE
Simple game state

### DIFF
--- a/server/src/game/game_state.rs
+++ b/server/src/game/game_state.rs
@@ -1,0 +1,21 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum UnitType {
+    Normal,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Unit {
+    pub position: (f32, f32),
+    pub unit_type: UnitType,
+    pub id: String,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct GameState {
+    //TODO Change this to https://docs.rs/chashmap/2.2.2/chashmap/
+    pub units: HashMap<String, Unit>,
+}

--- a/server/src/game/mod.rs
+++ b/server/src/game/mod.rs
@@ -1,0 +1,1 @@
+pub mod game_state;

--- a/server/src/handler.rs
+++ b/server/src/handler.rs
@@ -22,7 +22,6 @@ pub struct Event {
 
 pub async fn get_game_state_handler(game_state:GameStateRef) -> Result<impl Reply> {
     let game_state = &game_state.read().await.units;    
-    println!("{:?}",&game_state);
     let json = json(&game_state);
     Ok(json)
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -14,7 +14,6 @@ type Clients = Arc<RwLock<HashMap<String, Client>>>;
 #[derive(Debug, Clone)]
 pub struct Client {
     pub user_id: usize,
-    pub topics: Vec<String>,
     pub sender: Option<mpsc::UnboundedSender<std::result::Result<Message, warp::Error>>>,
 }
 
@@ -36,11 +35,6 @@ async fn main() {
             .and(with_clients(clients.clone()))
             .and_then(handler::unregister_handler));
 
-    let publish = warp::path!("publish")
-        .and(warp::body::json())
-        .and(with_clients(clients.clone()))
-        .and_then(handler::publish_handler);
-
     let ws_route = warp::path("ws")
         .and(warp::ws())
         .and(warp::path::param())
@@ -50,7 +44,6 @@ async fn main() {
     let routes = health_route
         .or(register_routes)
         .or(ws_route)
-        .or(publish)
         .with(warp::cors().allow_any_origin());
     let address = ([127, 0, 0, 1], 8000);
     println!("Listening on {:?}", address);

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -5,11 +5,15 @@ use std::sync::Arc;
 use tokio::sync::{mpsc, RwLock};
 use warp::{ws::Message, Filter, Rejection};
 
+use crate::game::game_state::GameState;
+
+mod game;
 mod handler;
 mod ws;
 
 type Result<T> = std::result::Result<T, Rejection>;
 type Clients = Arc<RwLock<HashMap<String, Client>>>;
+type GameStateRef = Arc<RwLock<GameState>>;
 
 #[derive(Debug, Clone)]
 pub struct Client {
@@ -22,6 +26,13 @@ async fn main() {
     let clients: Clients = Arc::new(RwLock::new(HashMap::new()));
 
     let health_route = warp::path!("health").and_then(handler::health_handler);
+
+    let game_state = Arc::new(RwLock::new(GameState::default()));
+
+    let game = warp::path("game");
+    let game_route = game.and(warp::get())
+        .and(with_game_state(game_state.clone()))
+        .and_then(handler::get_game_state_handler);
 
     let register = warp::path("register");
     let register_routes = register
@@ -38,10 +49,12 @@ async fn main() {
     let ws_route = warp::path("ws")
         .and(warp::ws())
         .and(warp::path::param())
-        .and(with_clients(clients.clone()))
+        .and(with_clients(clients))
+        .and(with_game_state(game_state))
         .and_then(handler::ws_handler);
 
     let routes = health_route
+        .or(game_route)
         .or(register_routes)
         .or(ws_route)
         .with(warp::cors().allow_any_origin());
@@ -52,4 +65,10 @@ async fn main() {
 
 fn with_clients(clients: Clients) -> impl Filter<Extract = (Clients,), Error = Infallible> + Clone {
     warp::any().map(move || clients.clone())
+}
+
+fn with_game_state(
+    game_state: GameStateRef,
+) -> impl Filter<Extract = (GameStateRef,), Error = Infallible> + Clone {
+    warp::any().map(move || game_state.clone())
 }


### PR DESCRIPTION
Add a very simple game state to the server.

This is mostly done to demonstrate how to use websockets and the warp library.
The server currently only takes two `RequestType`s . One for creating a unit, and one for updating a unit.

A route to get the current game state as JSON was also added:
http://localhost:8000/game

To test this out you can first send a post to the server:

```bash
curl -X POST 'http://localhost:8000/register' -H 'Content-Type: application/json' -d '{ "user_id": 1 }'
```

Then use ``https://www.websocket.org/echo.html`` to connect to the returned url.
Then send a message like: 
```json
{"CreatUnit":{"position":[10.0,15.0]}}
```

Then navigate to `http://localhost:8000/game` and see that your newly created units has been added.

