### PR TITLE
Use distroless docker image for server

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,4 @@
-FROM rust
-
+FROM gcr.io/distroless/cc
 WORKDIR /app
 EXPOSE 80
 EXPOSE 8000


### PR DESCRIPTION
This should make the docker image much smaller and safer. It should also lead to faster deploys.

The distroless images only contain what is needed for Rust to run not what is needed to build Rust. Also they are hardened.

See more at:
https://github.com/GoogleContainerTools/distroless