### PR TITLE
Generate JSON version of game cache once

### DIFF
--- a/server/src/handler.rs
+++ b/server/src/handler.rs
@@ -19,8 +19,7 @@ pub struct RegisterRequest {
 }
 
 pub async fn get_game_state_handler(game_state: GameStateRef) -> Result<impl Reply> {
-    let game_state = &game_state.read().await.units;
-    let json = json(&game_state);
+    let json = game_state.read().await.to_string();    
     Ok(json)
 }
 


### PR DESCRIPTION
This is done when writing the cache to memory, instead of generating it
every time the API is called.